### PR TITLE
fix: disable automatic releases for private repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,14 @@
 name: Release
 
+# Disabled for private repositories
+# Uncomment the 'on' section below when ready to publish to npm
+# on:
+#   push:
+#     branches: [main]
+#   workflow_dispatch:
+
+# Temporary: Only allow manual workflow dispatch for testing
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ loading for `bun run` commands. Keep it minimal and team-friendly.
 - **Wrong CLI package**: The binary is `changeset` (singular) provided by
   `@changesets/cli`. Installing `changesets` (plural) causes “could not
   determine executable” failures.
-- **Publishing blocked by `private: true`**: flip to `false` when you’re ready
-  to publish.
+- **Publishing blocked by `private: true`**: flip to `false` when you're ready
+  to publish. The release workflow is disabled by default for private packages.
+  To enable automatic releases, uncomment the push trigger in
+  `.github/workflows/release.yml`.
 - **Commit hooks aren’t absolute**: web UI commits and squash merges bypass
   local Husky; CI commitlint job is essential.
 - **Exports for libraries**: if you publish a library, build **Node‑targeted**


### PR DESCRIPTION
## Summary

- Disable automatic release workflow trigger for private repositories
- Change from push-triggered to manual dispatch only
- Update README documentation about private package configuration

## Problem

The release workflow was automatically creating Version Packages PRs even though the repository is set to private. This is unnecessary for private packages and can be confusing.

## Solution

1. Changed the release workflow trigger from `push` to `workflow_dispatch` only
2. Added comments explaining how to re-enable automatic releases when ready
3. Updated README.md with clear documentation about this behavior

## Test Plan

- [x] Workflow only runs on manual dispatch
- [x] README clearly documents the private package behavior
- [x] All existing CI checks pass

This ensures private repositories don't get unnecessary release PRs while keeping the option to easily enable it when the package is ready to be published.